### PR TITLE
Add support for armv6 (Raspberry PI 1)

### DIFF
--- a/buildwithdocker-armv6.sh
+++ b/buildwithdocker-armv6.sh
@@ -1,0 +1,24 @@
+# -e exit if any command fails, -x print commands as they are executed
+set -ex
+# make output dir
+mkdir -p build/armv6
+
+# set correct version
+GIT_COMMIT=`git rev-parse --short HEAD`
+GIT_TAG=`git describe --abbrev=0 --dirty`
+VERSION_STRING="$GIT_TAG ($GIT_COMMIT)"
+
+# build container
+docker buildx build --no-cache --progress plain -t "ogi-it/sdmon:latest" --platform linux/arm/v6 --build-arg "VERSION_STRING=${VERSION_STRING}" --load ./
+
+# create container
+docker create --name sdmonbuild ogi-it/sdmon
+
+# copy
+docker cp sdmonbuild:/usr/src/app/sdmon ./build/armv6
+base64 ./build/armv6/sdmon > ./build/armv6/sdmon.txt
+
+#cleanup
+docker container stop sdmonbuild
+docker container rm sdmonbuild
+docker image rm ogi-it/sdmon:latest


### PR DESCRIPTION
Tested on Kingston SDCIT2/16GB with and without -a
```
{
"version": "v0.4.3 (63a79fd)",
"date": "2023-07-21T00:12:39.000Z",
"device":"/dev/mmcblk0",
"addTime": "false",
"read_via_cmd56_arg_1":"read successful but signature 0xff 0xff",
"idata.response[]":"0x900 0x00 0x00 0x00",
"flashId": ["0x98","0x3e","0x98","0xb3","0x76","0xe3","0x08","0x16","0x00"],
"icVersion": ["0x1f","0xc3"],
"fwVersion": [38,240],
"ceNumber": "0x01",
"spareBlockCount": 10,
"initialBadBlockCount": 7,
"goodBlockRatePercent": 99.82,
"totalEraseCount": 2788,
"enduranceRemainLifePercent": 100.00,
"avgEraseCount": 1,
"minEraseCount": 1,
"maxEraseCount": 13,
"powerUpCount": 23,
"abnormalPowerOffCount": 0,
"totalRefreshCount": 0,
"productMarker": ["0x70","0x53","0x4c","0x43","0x00","0x00","0x00","0x00"],
"laterBadBlockCount": 0,
"success":true
}
```
