### PR TITLE
Add support for Transcend cards

### DIFF
--- a/src/sdmon.c
+++ b/src/sdmon.c
@@ -252,6 +252,75 @@ int main(int argc, const char *argv[]) {
     exit(0);
   }
 
+  //try transcend argument
+  cmd56_arg = 0x110005f9;
+  ret = CMD56_data_in(fd, cmd56_arg, data_in);
+  // we assume success when the call was successful AND the signature is not 0xff 0xff
+  if (ret == 0 && !((data_in[0] == 0xff && data_in[1] == 0xff) || (data_in[0] == 0x00 && data_in[1] == 0x00))) {
+	printf("\"signature\":\"0x%x 0x%x\",\n", data_in[0], data_in[1]);
+	if (data_in[0] == 0x54 && data_in[1] == 0x72) {
+		printf("\"Transcend\":\"true\",\n");
+		printf("\"Secured mode\": %d,\n", (int)(data_in[11]));
+	switch (data_in[16])
+	{
+		case 0x00:
+			printf("\"Bus width\": 1 bit\n");
+			break;
+		case 0x10:
+			printf("\"Bus width\": 4 bits\n");
+			break;
+	}
+	switch (data_in[18])
+	{
+		case 0x00:
+			printf("\"Speed mode\": Class 0\n");
+			break;
+		case 0x01:
+			printf("\"Speed mode\": Class 2\n");
+			break;
+		case 0x02:
+			printf("\"Speed mode\": Class 4\n");
+			break;
+		case 0x03:
+			printf("\"Speed mode\": Class 6\n");
+			break;
+		case 0x04:
+			printf("\"Speed mode\": Class 10\n");
+			break;
+	}
+	switch (data_in[19])
+	{
+		case 0x00:
+			printf("\"UHS speed grade\": Less than 10MB/s\n");
+			break;
+		case 0x01:
+			printf("\"UHS speed grade\": 10MB/s and higher\n");
+			break;
+		case 0x03:
+			printf("\"UHS speed grade\": 30MB/s and higher\n");
+			break;
+	}
+	printf("\"New bad blocks cnt\": 0x%02x,\n", data_in[26]);
+	printf("\"Runtime spare blocks cnt\": 0x%02x,\n", data_in[27]);
+	printf("\"Abnormal power loss\": %ld,\n", (long)((data_in[31] << 24) + (data_in[30] << 16) + (data_in[29] << 8) + data_in[28]));
+	printf("\"Minimum erase cnt\": %d,\n", (long)((data_in[35] << 24) + (data_in[34] << 16) + (data_in[33] << 8) + data_in[32]));
+	printf("\"Maximum erase cnt\": %d,\n", (long)((data_in[39]) + (data_in[38]) + (data_in[37]) + data_in[36]));
+	printf("\"Average erase cnt\": %d,\n", (long)((data_in[47] << 24) + (data_in[46] << 16) + (data_in[45] << 8) + data_in[44]));
+   
+	printf("\"Remaining card life\": %d%,\n", (int)(data_in[70]));
+	printf("\"Total write CRC cnt\": %d,\n", bytes_to_int(data_in[72], data_in[73], data_in[74], data_in[75]));
+	printf("\"Power cycle cnt\": %d,\n", bytes_to_int(0, 0, data_in[76], data_in[77]));
+    
+	printf("\"NAND flash ID\": 0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,\n", data_in[80], data_in[81], data_in[82], data_in[83], data_in[84], data_in[85]);
+	printf("\"IC\": %c%c%c%c%c%c%c%c,\n", data_in[87], data_in[88], data_in[89], data_in[90], data_in[91], data_in[92], data_in[93], data_in[94]);
+	printf("\"fw version\": %c%c%c%c%c%c,\n", data_in[128], data_in[129], data_in[130], data_in[131], data_in[132], data_in[133]);
+
+	close(fd);
+	printf("\"success\":true\n}\n");
+	exit(0);
+	}
+}
+
   // try micron argument
   cmd56_arg = 0x110005fb;
   ret = CMD56_data_in(fd, cmd56_arg, data_in);


### PR DESCRIPTION
Vendor provides code in Github but their code was not used for this patch.

Compiled and tested using a brand new 230I 32GB card on my T6 ARM board:

sudo ./sdmon /dev/mmcblk0
{
{
"version": "abc222",
"date": "2024-01-04T21:38:28.000Z",
"device":"/dev/mmcblk0",
"addTime": "false",
"signature":"0x54 0x72",
"Transcend":"true",
"Secured mode": 0,
"Bus width": 4 bits
"Speed mode": Class 10
"UHS speed grade": 30MB/s and higher
"New bad blocks cnt": 0x00,
"Runtime spare blocks cnt": 0x33,
"Abnormal power loss": 0,
"Minimum erase cnt": 0,
"Maximum erase cnt": 1,
"Average erase cnt": 0,
"Remaining card life": 100%,
"Total write CRC cnt": 0,
"Power cycle cnt": 0,
"NAND flash ID": 0x45,0x3c,0x98,0xb3,0x76,0x6b,
"IC": SM2707E,
"fw version": T0408 ,
"success":true
}

Cards below 8GB have different offsets for their data so they will not work properly.