### PR TITLE
Add support for Adata cards

### DIFF
--- a/src/sdmon.c
+++ b/src/sdmon.c
@@ -252,6 +252,46 @@ int main(int argc, const char *argv[]) {
     exit(0);
   }
 
+  //try adata argument
+  cmd56_arg = 0x110005f1;
+  ret = CMD56_data_in(fd, cmd56_arg, data_in);
+  // we assume success when the call was successful AND the signature is not 0xff 0xff
+  if (ret == 0 && !((data_in[0] == 0xff && data_in[1] == 0xff) || (data_in[0] == 0x00 && data_in[1] == 0x00))) {
+	printf("\"signature\":\"0x%x 0x%x\",\n", data_in[0], data_in[1]);
+	if (data_in[0] == 0x09 && data_in[1] == 0x41) {
+	printf("\"Adata\":\"true\",\n");
+	printf("\"Factory bad block cnt\": %d,\n", (int)((data_in[24] << 8) + data_in[25]));
+	printf("\"Grown bad block cnt\": %d,\n", (int)(data_in[26]));
+	printf("\"Spare SLC block cnt\": %d,\n", (int)(data_in[27]));
+	printf("\"Spare block cnt\": %d,\n", (int)((data_in[30] << 8) + data_in[31]));
+	printf("\"Data area minimum erase cnt\": %ld,\n", (long)((data_in[32] << 24) + (data_in[33] << 16) + (data_in[34] << 8) + data_in[35]));
+	printf("\"Data area maximum erase cnt\": %ld,\n", (long)((data_in[36] << 24) + (data_in[37] << 16) + (data_in[38] << 8) + data_in[39]));
+	printf("\"Data area total erase cnt\": %ld,\n", (long)((data_in[40] << 24) + (data_in[41] << 16) + (data_in[42] << 8) + data_in[43]));
+	printf("\"Data area average erase cnt\": %ld,\n", (long)((data_in[44] << 24) + (data_in[45] << 16) + (data_in[46] << 8) + data_in[47]));
+	printf("\"System area minimum erase cnt\": %ld,\n", (long)((data_in[48] << 24) + (data_in[49] << 16) + (data_in[50] << 8) + data_in[51]));
+	printf("\"System area maximum erase cnt\": %ld,\n", (long)((data_in[52] << 24) + (data_in[53] << 16) + (data_in[54] << 8) + data_in[55]));
+	printf("\"System area total erase count\": %ld,\n", (long)((data_in[56] << 24) + (data_in[57] << 16) + (data_in[58] << 8) + data_in[59]));
+	printf("\"System area average erase cnt\": %ld,\n", (long)((data_in[60] << 24) + (data_in[61] << 16) + (data_in[62] << 8) + data_in[63]));
+	printf("\"Raw card capacity\": %ld MB,\n", (long)((data_in[64] << 24) + (data_in[65] << 16) + (data_in[66] << 8) + data_in[67]));
+	printf("\"PE Cycle life\": %ld,\n", (long)((data_in[68] << 8) + data_in[69]));
+	printf("\"Remaining life\": %d%%,\n", (int)data_in[70]);
+	printf("\"Power cucle cnt\": %ld,\n", (long)((data_in[76] << 24) + (data_in[77] << 16) + (data_in[78] << 8) + data_in[79]));
+	printf("\"Flash ID\": 0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,\n", data_in[80], data_in[81], data_in[82], data_in[83], data_in[84], data_in[85], data_in[86]);
+	printf("\"Controller\": %c%c%c%c%c%c%c,\n", data_in[88], data_in[89], data_in[90], data_in[91], data_in[92], data_in[93]);
+	printf("\"TLC read reclaim\": %ld,\n", (long)((data_in[96] << 8) + data_in[97]));
+	printf("\"SLC read reclaim\": %ld,\n", (long)((data_in[98] << 8) + data_in[99]));
+	printf("\"Firmware block refresh\": %ld,\n", (long)((data_in[100] << 8) + data_in[101]));
+	printf("\"TLC read threshold\": %ld,\n", (long)((data_in[104] << 24) + (data_in[105] << 16) + (data_in[106] << 8) + data_in[107]));
+	printf("\"SLC read threshold\": %ld,\n", (long)((data_in[108] << 24) + (data_in[109] << 16) + (data_in[110] << 8) + data_in[111]));
+	printf("\"FW version\": %c%c%c%c%c%c%c,\n", data_in[128], data_in[129], data_in[130], data_in[131], data_in[132], data_in[133]);
+	printf("\"TLC refresh cnt\": %d,\n", (int)((data_in[136] << 24) + (data_in[137] << 16) + (data_in[138] << 8) + data_in[139]));
+	printf("\"SLC refresh cnt\": %d,\n", (int)((data_in[140] << 24) + (data_in[141] << 16) + (data_in[143] << 8) + data_in[144]));
+ 	close(fd);
+	printf("\"success\":true\n}\n");
+	exit(0);
+	}
+}
+
   //try transcend argument
   cmd56_arg = 0x110005f9;
   ret = CMD56_data_in(fd, cmd56_arg, data_in);
@@ -313,7 +353,7 @@ int main(int argc, const char *argv[]) {
     
 	printf("\"NAND flash ID\": 0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,0x%02x,\n", data_in[80], data_in[81], data_in[82], data_in[83], data_in[84], data_in[85]);
 	printf("\"IC\": %c%c%c%c%c%c%c%c,\n", data_in[87], data_in[88], data_in[89], data_in[90], data_in[91], data_in[92], data_in[93], data_in[94]);
-	printf("\"fw version\": %c%c%c%c%c%c,\n", data_in[128], data_in[129], data_in[130], data_in[131], data_in[132], data_in[133]);
+	printf("\"FW version\": %c%c%c%c%c%c,\n", data_in[128], data_in[129], data_in[130], data_in[131], data_in[132], data_in[133]);
 
 	close(fd);
 	printf("\"success\":true\n}\n");
@@ -347,7 +387,7 @@ int main(int argc, const char *argv[]) {
 
     if (data_in[0] == 0x53 && data_in[1] == 0x77) {
       printf("\"Swissbit\":\"true\",\n");
-      printf("\"fwVersion\": [%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c],\n", data_in[32], data_in[33], data_in[34], data_in[35], data_in[36], data_in[37], data_in[38], data_in[39], data_in[40],
+      printf("\"FW version\": [%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c],\n", data_in[32], data_in[33], data_in[34], data_in[35], data_in[36], data_in[37], data_in[38], data_in[39], data_in[40],
              data_in[41], data_in[42], data_in[43], data_in[44], data_in[45], data_in[46], data_in[47]); // show char
       printf("\"User area rated cycles\": [\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n", data_in[48], data_in[49], data_in[50], data_in[51]);
       printf("\"User area max cycle cnt\": [\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n", data_in[52], data_in[53], data_in[54], data_in[55]);


### PR DESCRIPTION
Vendor does not provide useful public documentation. I have not contacted vendor since there is public source available at project SDeMMCHealth of Github.

Card will also reply on Transcend argument and disguise as such card successfully :)

Compiled and tested using a brand new IUDD33K 64GB card on my T6 ARM board: sudo ./sdmona /dev/mmcblk0
{
"version": "abc234",
"date": "2024-01-07T23:19:43.000Z",
"device":"/dev/mmcblk0",
"addTime": "false",
"signature":"0x9 0x41",
"Adata":"true",
"Factory bad block cnt": 10,
"Grown bad block cnt": 0,
"Spare SLC block cnt": 34,
"Spare block cnt": 0,
"Data area minimum erase cnt": 0,
"Data area maximum erase cnt": 1,
"Data area total erase cnt": 2,
"Data area average erase cnt": 0,
"System area minimum erase cnt": 0,
"System area maximum erase cnt": 1,
"System area total erase count": 11,
"System area average erase cnt": 0,
"Raw card capacity": 60351 MB,
"PE Cycle life": 30,
"Remaining life": 100%,
"Power cucle cnt": 6,
"Flash ID": 0x45,0x3e,0x98,0x03,0x76,0x64,
"Controller": SM2706,
"TLC read reclaim": 0,
"SLC read reclaim": 0,
"Firmware block refresh": 0,
"TLC read threshold": 1000,
"SLC read threshold": 2000,
"FW version": V0217 ,
"TLC refresh cnt": 0,
"SLC refresh cnt": 29,
"success":true
}