### PR TITLE
Adjust Swissbit fields to spec

### DIFF
--- a/src/sdmon.c
+++ b/src/sdmon.c
@@ -147,14 +147,28 @@ void dump_data_block(char *lba_block_data) {
   return;
 }
 
+// convert Big Endian ordered bytes to int
 int bytes_to_int(unsigned char byte1, unsigned char byte2, unsigned char byte3, unsigned char byte4) { return (byte1 << 24) | (byte2 << 16) | (byte3 << 8) | byte4; }
 
+// convert Little Endian words to int
 int nword_to_int(unsigned char *data, int offset, int size) {
   if (size == 4) {
     return ((data[offset + 3] << 24) | (data[offset + 2] << 16) | (data[offset + 1] << 8) | data[offset]);
   } else if (size == 8) {
     return (((long long)data[offset + 3] << 56) | ((long long)data[offset + 3] << 48) | ((long long)data[offset + 3] << 40) | ((long long)data[offset + 3] << 32) |
             ((long long)data[offset + 3] << 24) | ((long long)data[offset + 2] << 16) | ((long long)data[offset + 1] << 8) | (long long)data[offset]);
+  } else {
+    return -1;
+  }
+}
+
+// convert Big Endian words to int
+int nwordbe_to_int(unsigned char *data, int offset, int size) {
+  if (size == 4) {
+    return ((data[offset] << 24) | (data[offset + 1] << 16) | (data[offset + 2] << 8) | data[offset + 3]);
+  } else if (size == 8) {
+    return (((long long)data[offset] << 56) | ((long long)data[offset + 1] << 48) | ((long long)data[offset + 2] << 40) | ((long long)data[offset + 3] << 32) |
+            ((long long)data[offset + 4] << 24) | ((long long)data[offset + 5] << 16) | ((long long)data[offset + 6] << 8) | (long long)data[offset + 7]);
   } else {
     return -1;
   }
@@ -405,15 +419,16 @@ int main(int argc, const char *argv[]) {
 
     if (data_in[0] == 0x53 && data_in[1] == 0x77) {
       printf("\"Swissbit\":\"true\",\n");
-      printf("\"fwVersion\": [%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c,%c],\n", data_in[32], data_in[33], data_in[34], data_in[35], data_in[36], data_in[37], data_in[38], data_in[39], data_in[40],
-             data_in[41], data_in[42], data_in[43], data_in[44], data_in[45], data_in[46], data_in[47]); // show char
-      printf("\"User area rated cycles\": [\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n", data_in[48], data_in[49], data_in[50], data_in[51]);
-      printf("\"User area max cycle cnt\": [\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n", data_in[52], data_in[53], data_in[54], data_in[55]);
-      printf("\"User area total cycle cnt\": [\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n", data_in[56], data_in[57], data_in[58], data_in[59]);
-      printf("\"User area average cycle cnt\": [\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n", data_in[60], data_in[61], data_in[62], data_in[63]);
-      printf("\"System area max cycle cnt\": [\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n", data_in[68], data_in[69], data_in[70], data_in[71]);
-      printf("\"System area total cycle cnt\": [\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n", data_in[72], data_in[73], data_in[74], data_in[75]);
-      printf("\"System area average cycle cnt\": [\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n", data_in[76], data_in[77], data_in[78], data_in[79]);
+      strncpy(tmpstr, (char *)&data_in[32], 16);
+      tmpstr[16] = 0;
+      printf("\"fwVersion\": \"%s\",\n", tmpstr);
+      printf("\"User area rated cycles\": %d,\n", nwordbe_to_int(data_in, 48, 4));
+      printf("\"User area max cycle cnt\": %d,\n", nwordbe_to_int(data_in, 52, 4));
+      printf("\"User area total cycle cnt\": %d,\n", nwordbe_to_int(data_in, 56, 4));
+      printf("\"User area average cycle cnt\": %d,\n", nwordbe_to_int(data_in, 60, 4));
+      printf("\"System area max cycle cnt\": %d,\n", nwordbe_to_int(data_in, 68, 4));
+      printf("\"System area total cycle cnt\": %d,\n", nwordbe_to_int(data_in, 72, 4));
+      printf("\"System area average cycle cnt\": %d,\n", nwordbe_to_int(data_in, 76, 4));
       printf("\"Remaining Lifetime Percent\": %d%%,\n", (int)(data_in[80]));
       switch (data_in[86]) {
       case 0x00:
@@ -446,14 +461,14 @@ int main(int argc, const char *argv[]) {
         printf("\"Bus width\": 4 bits\n");
         break;
       }
-      printf("\"User area spare blocks cnt\": [\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n", data_in[88], data_in[89], data_in[90], data_in[91]);
-      printf("\"System area spare blocks cnt\": [\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n", data_in[92], data_in[93], data_in[94], data_in[95]);
-      printf("\"User area runtime bad blocks cnt\": [\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n", data_in[96], data_in[97], data_in[98], data_in[99]);
-      printf("\"System area runtime bad blocks cnt\": [\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n", data_in[100], data_in[101], data_in[102], data_in[103]);
-      printf("\"User area refresh cnt\": [\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n", data_in[104], data_in[105], data_in[106], data_in[107]);
-      printf("\"System area refresh cnt\": [\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n", data_in[108], data_in[109], data_in[110], data_in[111]);
-      printf("\"Interface crc cnt\": [\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n", data_in[112], data_in[113], data_in[114], data_in[115]);
-      printf("\"Power cycle cnt\": [\"%d\",\"%d\",\"%d\",\"%d\"],\n", data_in[116], data_in[117], data_in[118], data_in[119]);
+      printf("\"User area spare blocks cnt\": %d,\n", nwordbe_to_int(data_in, 88, 4));
+      printf("\"System area spare blocks cnt\": %d,\n", nwordbe_to_int(data_in, 92, 4));
+      printf("\"User area runtime bad blocks cnt\": %d,\n", nwordbe_to_int(data_in, 96, 4));
+      printf("\"System area runtime bad blocks cnt\": %d,\n", nwordbe_to_int(data_in, 100, 4));
+      printf("\"User area refresh cnt\": %d,\n", nwordbe_to_int(data_in, 104, 4));
+      printf("\"System area refresh cnt\": %d,\n", nwordbe_to_int(data_in, 108, 4));
+      printf("\"Interface crc cnt\": %d,\n", nwordbe_to_int(data_in, 112, 4));
+      printf("\"Power cycle cnt\": %d,\n", nwordbe_to_int(data_in, 116, 4));
       close(fd);
       printf("\"success\":true\n}\n");
       exit(0);


### PR DESCRIPTION
Convert char arrays to strings or
integers, following the spec.

Integers are in Big Endian order,
so add a nwordbe_to_int func to mimic
nword_to_int but for BE instead of LE.