### PR TITLE
fix: some Swissbit fields were not using the JSON lib

### DIFF
--- a/src/sdmon.c
+++ b/src/sdmon.c
@@ -474,7 +474,7 @@ int main(int argc, const char *argv[]) {
     json_object_push(j, "signature", json_sprintf_new("0x%x 0x%x", data_in[0], data_in[1]));
 
     if (data_in[0] == 0x53 && data_in[1] == 0x77) {
-      printf("\"Swissbit\":\"true\",\n");
+      json_object_push(j, "Swissbit", json_boolean_new(1));
       strncpy(tmpstr, (char *)&data_in[32], 16);
       tmpstr[16] = 0;
       json_object_push(j, "fwVersion", json_string_new(tmpstr));
@@ -564,14 +564,10 @@ int main(int argc, const char *argv[]) {
   //  dump_data_block(data_in);
   //  printf("\",\n");
 
-  printf("\"flashId\": "
-         "[\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\",\"0x%02x\","
-         "\"0x%02x\",\"0x%02x\",\"0x%02x\"],\n",
-         data_in[0], data_in[1], data_in[2], data_in[3], data_in[4], data_in[5], data_in[6], data_in[7], data_in[8]);
-  printf("\"icVersion\": [\"0x%02x\",\"0x%02x\"],\n", data_in[9], data_in[10]);
-  printf("\"fwVersion\": [%02d,%02d],\n", data_in[11],
-         data_in[12]); // show in decimal
-  printf("\"ceNumber\": \"0x%02x\",\n", data_in[14]);
+   json_object_push(j, "flashId", json_array_build("0x%02x", data_in, 0, 9));
+   json_object_push(j, "icVersion", json_array_build("0x%02x", data_in, 9, 2));
+   json_object_push(j, "fwVersion", json_array_build("%02d", data_in, 11, 2)); // show in decimal
+   json_object_push(j, "ceNumber", json_sprintf_new("0x%02x", data_in[14]));
 
   // printf("\"badBlockReplaceMaximum\": [\"0x%02x\",\"0x%02x\"],\n", data_in[16], data_in[17]);
   // badBlockReplaceMaximum is spareBlockCount

--- a/src/sdmon.c
+++ b/src/sdmon.c
@@ -335,6 +335,7 @@ int main(int argc, const char *argv[]) {
     json_object_push(j, "powerOnTimes", json_integer_new(bytes_to_int(0, data_in[24], data_in[25], data_in[26])));
     close(fd);
     json_object_push(j, "success", json_boolean_new(1));
+    json_print_and_free(j);
     exit(0);
   }
 
@@ -375,6 +376,7 @@ int main(int argc, const char *argv[]) {
       json_object_push(j, "SLC refresh cnt", json_integer_new((int)((data_in[140] << 24) + (data_in[141] << 16) + (data_in[143] << 8) + data_in[144])));
       close(fd);
       json_object_push(j, "success", json_boolean_new(1));
+      json_print_and_free(j);
       exit(0);
     }
   }
@@ -443,6 +445,7 @@ int main(int argc, const char *argv[]) {
 
       close(fd);
       json_object_push(j, "success", json_boolean_new(1));
+      json_print_and_free(j);
       exit(0);
     }
   }
@@ -461,6 +464,7 @@ int main(int argc, const char *argv[]) {
       json_object_push(j, "SLC area utilization", json_integer_new((int)(data_in[9])));
       close(fd);
       json_object_push(j, "success", json_boolean_new(1));
+      json_print_and_free(j);
       exit(0);
     }
   }
@@ -527,6 +531,7 @@ int main(int argc, const char *argv[]) {
       json_object_push(j, "Power cycle cnt", json_integer_new(nwordbe_to_int(data_in, 116, 4)));
       close(fd);
       json_object_push(j, "success", json_boolean_new(1));
+      json_print_and_free(j);
       exit(0);
     }
   }
@@ -633,6 +638,6 @@ int main(int argc, const char *argv[]) {
 
   close(fd);
   json_object_push(j, "success", json_boolean_new(1));
-
+  json_print_and_free(j);
   exit(0);
 }


### PR DESCRIPTION
For some reason, I overlooked converting 4 of the Swissbit fields printfs into json lib calls. Looked at all the remaining "printf", in the code, it seems on now!

The few other features i'd like to add:
- a few more options on the cmdline, while not making it too complicated either. Mainly -q/-v to control message output from quiet to debug levels, and a switch to force one of the methods instead of trying to autodetect until it works (which will remain the default). This way, once you know which method works well with your SD card, you can specify it directly. Also if a card answers to several query types but only one doesn't output garbage, you'll be able to force it too.
- a parameter to mock the cmd56 output with a given query method, i.e. give it a file of 512 bytes which will be taken as the answer to cmd56, if we want to run some automated tests.