### PR TITLE
Display FreeBSD sdmon port version.

### DIFF
--- a/src/Makefile.freebsd
+++ b/src/Makefile.freebsd
@@ -1,6 +1,13 @@
 # (c)2018 ogi-it, Ognian Tschakalov
 
-#VERSION = 0.01
+FILE_PATH = ../freebsd_portversion.txt 
+
+.if exists(${FILE_PATH})
+VERSION_STRING != cat ../freebsd_portversion.txt
+.else
+VERSION_STRING != git describe --always
+.endif
+
 CC      = /usr/bin/cc
 CFLAGS  = -Wall -g -D_REENTRANT -DVERSION="\"$(VERSION_STRING)\"" -I. -static
 LDFLAGS = -lm


### PR DESCRIPTION
Allow display of FreeBSD port version.

root@orangepione:~/sdmon/src # ./sdmon /dev/mmcsd0
Trying sandisk...
{
  "version": "0.9.0",
  "date": "2026-03-12T19:58:07.000",
  "device": "/dev/mmcsd0",
  "addTime": false,
  "method": "auto",
  "signature": "0x44 0x53",
  "SanDisk": true,
  "manufactureYYMMDD": "210415",
  "healthStatusPercentUsed": 1,
  "featureRevision": "0x1f",
  "generationIdentifier": 5,
  "productString": "SanDisk                         ",
  "powerOnTimes": 25,
  "success": true
}
